### PR TITLE
Fixes for `awdur export`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 __pycache__
 *.pyc
+result

--- a/lib/awdur/awdur/cli/_core.py
+++ b/lib/awdur/awdur/cli/_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import bdb
 import inspect
 import logging
 import typing
@@ -49,6 +50,7 @@ def get_parser(commands: Dict[str, Callable]) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Literate programming tools built on docutils."
     )
+    parser.add_argument("--debug", action="store_true", help="enable debug mode")
 
     subcommands = parser.add_subparsers(title="commands")
 
@@ -84,5 +86,13 @@ def main(argv: Optional[Sequence[str]] = None):
     try:
         call(setup_logging, arguments)
         call(command, arguments)
+    except bdb.BdbQuit:
+        # Don't debug exiting from the debugger.
+        pass
     except Exception as exc:
         logger.error("%s", exc)
+
+        if arguments.get("debug", False):
+            import pdb
+
+            pdb.post_mortem()

--- a/lib/awdur/awdur/cli/export.py
+++ b/lib/awdur/awdur/cli/export.py
@@ -101,8 +101,10 @@ def export(source: pathlib.Path, destination: pathlib.Path):
     destination
        The location to write to
     """
+
     project = publish_parts(
         source=source.read_text(),
+        source_path=str(source),
         # destination_path="out.html",  # sys.stdout,
         writer=SourceCodeWriter(),
     )

--- a/lib/awdur/awdur/cli/export.py
+++ b/lib/awdur/awdur/cli/export.py
@@ -60,19 +60,17 @@ class ExtractCodeTransform(Transform):
         visitor = CodeMetdataVisitor(self.document)
         self.document.walk(visitor)
 
-        code_blocks = self.document.findall(nodes.literal_block)
-        self.document.children = list(code_blocks)
-
 
 class SourceCodeWriter(Writer):
     """A writer for writing source code."""
 
     def get_transforms(self):
-        return super().get_transforms() + [ExtractCodeTransform]
+        return [ExtractCodeTransform]
 
     def translate(self):
         all_filenames = set()
-        for node in self.document.children:
+
+        for node in self.document.findall(nodes.literal_block):
             filename = node.attributes.get("filename", "<<default>>")
             all_filenames.add(filename)
             self.parts.setdefault(filename, []).append(node.astext())

--- a/lib/awdur/changes/16.fix.md
+++ b/lib/awdur/changes/16.fix.md
@@ -1,0 +1,1 @@
+When using `awdur export`, `.. include::` directives should now resolve correctly.

--- a/lib/awdur/changes/16.fix.md
+++ b/lib/awdur/changes/16.fix.md
@@ -1,1 +1,0 @@
-When using `awdur export`, `.. include::` directives should now resolve correctly.

--- a/lib/awdur/changes/17.fix.md
+++ b/lib/awdur/changes/17.fix.md
@@ -1,0 +1,3 @@
+When using `awdur export`, `.. include::` directives should now resolve correctly.
+
+The `awdur export` command should no longer crash when processing documents containing `.. contents::` directives.


### PR DESCRIPTION
- By setting the `source_path`, `.. include::` directives should now resolve correctly.
- By not drastically editing the doctree, exporting documents containing `.. contents::` directives should no longer fail.