### PR TITLE
Add a header to `.. code-block::` directives

### DIFF
--- a/lib/awdur/awdur/ext.py
+++ b/lib/awdur/awdur/ext.py
@@ -36,7 +36,20 @@ class CodeFragment(CodeBlock):
             print(f"Unable to process {code}")
             return result
 
-        code.attributes["filename"] = self.options.get("filename")
+        if (filename := self.options.get("filename")) is not None:
+            code.attributes["filename"] = filename
+
+            # Add a header to the code block indicating where it is being saved to.
+            header = nodes.container(
+                "",
+                nodes.literal("", filename, classes=["awdur-codeblock-filename"]),
+                classes=["awdur-codeblock-header"]
+            )
+            result.insert(0, header)
+
+            container = nodes.container("", *result, classes=["awdur-codeblock"])
+            return [container]
+
         return result
 
 

--- a/lib/awdur/awdur/ext.py
+++ b/lib/awdur/awdur/ext.py
@@ -115,8 +115,8 @@ class SourceCodeBuilder(Builder):
 
 
 def setup(app: Sphinx):
-    app.add_directive("code-block", CodeFragment)
-    app.add_directive("sourcecode", CodeFragment)
+    app.add_directive("code-block", CodeFragment, override=True)
+    app.add_directive("sourcecode", CodeFragment, override=True)
 
     app.add_builder(SourceCodeBuilder)
 

--- a/lib/awdur/changes/22.enhancement.md
+++ b/lib/awdur/changes/22.enhancement.md
@@ -1,0 +1,1 @@
+`.. code-blocks::` managed by awdur now include a header that indicates which file the content belongs to


### PR DESCRIPTION
This shows which file the associated content belongs to